### PR TITLE
Added badge back to the README 🛡

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,20 @@
 # Rigoblock
-
+[![CircleCI](https://circleci.com/gh/RigoBlock/rigoblock-monorepo/tree/master.svg?style=shield&circle-token=8a3a97d8673b72dacc5efb04a10492ce473e9afb)](https://circleci.com/gh/RigoBlock/rigoblock-monorepo/tree/master)
 ---
-
-
-
 
 ## Packages
 
-| Package                                                         | Description                                                      |
-| --------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [`Rigoblock Dapp`](/packages/rigoblock-dapp)                    | Rigoblock Dapp                                                   |
-| [`Pool API`](/packages/rigoblock-pool-api)                      | A wrapper library with preset rpc calls to our pools.            |
-| [`Rigoblock Protocol`](/packages/rigoblock-protocol)            | Rigoblock Protocol                                               |
-
-
+| Package| Description|
+| - | - |
+| [`Rigoblock Dapp`](/packages/rigoblock-dapp) | Rigoblock Dapp |
+| [`Pool API`](/packages/rigoblock-pool-api) | A wrapper library with preset rpc calls to our pools |
+| [`Rigoblock Protocol`](/packages/rigoblock-protocol) | Rigoblock Protocol |
 
 ### Install dependencies
 
 ```
 yarn bootstrap
 ```
-
 
 ### Lint
 


### PR DESCRIPTION
resolves #47 

#### :notebook: Overview
this adds the cricleCI badge to show master build status

