### PR TITLE
NGINX

### DIFF
--- a/packages/dapp/Dockerfile
+++ b/packages/dapp/Dockerfile
@@ -37,23 +37,12 @@ RUN npm i -g yarn
 RUN yarn --pure-lockfile
 RUN yarn build
 
-# setup gwan on alpine linux, copy dist folder from builder image onto gwan's folder
+# setup nginx on alpine linux, copy dist folder from builder image onto nginx's folder
+FROM nginx:stable-alpine
 
-FROM jeanblanchard/alpine-glibc
-
-RUN apk update && apk add alpine-sdk curl bzip2
-
-RUN mkdir /opt
-
-RUN curl http://gwan.com/archives/gwan_linux64-bit.tar.bz2 | tar xj -C /opt
-RUN mv /opt/gwan_linux64-bit /opt/gwan && \
-  rm -rf /opt/gwan/0.0.0.0:* && \
-  mkdir -p /opt/gwan/0.0.0.0:8080/#0.0.0.0/www
-
-COPY --from=builder /src/dist /opt/gwan/0.0.0.0:8080/#0.0.0.0/www
-
-RUN apk del curl bzip2
+COPY --from=builder /src/dist /usr/share/nginx/html
+COPY packages/dapp/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 8080
 
-CMD /opt/gwan/gwan
+CMD ["nginx-debug", "-g", "daemon off;"]

--- a/packages/dapp/nginx.conf
+++ b/packages/dapp/nginx.conf
@@ -1,0 +1,59 @@
+#user  nobody;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log;
+
+pid        /var/run/nginx.pid ;
+
+worker_rlimit_nofile   51200;
+
+events {
+    use                epoll;
+    worker_connections 51200;
+    multi_accept       on;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    charset         UTF-8;
+
+    access_log  /var/log/nginx/access.log;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+
+    keepalive_timeout  60;
+
+    fastcgi_connect_timeout   300;
+    fastcgi_send_timeout      300;
+    fastcgi_read_timeout      300;
+    fastcgi_buffer_size       64k;
+    fastcgi_buffers           4 64k;
+    fastcgi_busy_buffers_size 128k;
+    fastcgi_temp_file_write_size 256k;
+
+    gzip               on;
+    gzip_vary          on;
+    gzip_comp_level    6;
+    gzip_buffers       16 8k;
+    gzip_min_length    1000;
+    gzip_proxied       any;
+    gzip_disable       "msie6";
+    gzip_http_version  1.0;
+    gzip_types         text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript image/svg+xml;
+
+    server {
+        listen 8080;
+        server_name  localhost;
+
+        root   /usr/share/nginx/html;
+        index  index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
resolves https://github.com/RigoBlock/rigoblock-monorepo/issues/72 

#### :notebook: Overview
This enables nginx instead of g-wan w/ compression, route resolver and https + http/2
