### PR TITLE
Publish 7

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rigoblock/api",
   "description": "A JS wrapper around RigoBlock Smart Contracts to simplify their consumption.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
@@ -27,7 +27,7 @@
     "@0xproject/subproviders": "^0.10.4",
     "@0xproject/typescript-typings": "^0.4.1",
     "@0xproject/web3-wrapper": "^0.7.1",
-    "@rigoblock/protocol": "^0.2.7",
+    "@rigoblock/protocol": "^0.2.8",
     "@types/node": "^9.6.6",
     "bignumber.js": "^5.0.0",
     "typechain": "^0.2.2",

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rigoblock/dapp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "start": "serve -s dist -p 8080",
@@ -24,8 +24,8 @@
     "mnemonic": "lemon scrub wasp bracket town boat property sadness layer taxi butter audit"
   },
   "devDependencies": {
-    "@rigoblock/api": "^0.2.3",
-    "@rigoblock/ganache-bootstrap": "^0.1.10",
+    "@rigoblock/api": "^0.2.4",
+    "@rigoblock/ganache-bootstrap": "^0.1.11",
     "@storybook/addon-info": "^3.4.8",
     "@storybook/addon-knobs": "^3.4.8",
     "@storybook/addon-options": "^3.4.8",
@@ -149,7 +149,7 @@
     ]
   },
   "dependencies": {
-    "@rigoblock/protocol": "^0.2.7",
+    "@rigoblock/protocol": "^0.2.8",
     "core-js": "3.0.0-beta.3"
   }
 }

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rigoblock/deployer",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Smart contract deployer",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ganache-bootstrap/package.json
+++ b/packages/ganache-bootstrap/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@rigoblock/ganache-bootstrap",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "bin": {
     "ganache-bootstrap": "bin/ganache-bootstrap.js",
     "ganache-seed": "bin/ganache-seed.js"
   },
   "dependencies": {
-    "@rigoblock/protocol": "^0.2.7",
+    "@rigoblock/protocol": "^0.2.8",
     "chalk": "^2.3.2",
     "pino": "^4.15.3",
     "web3": "^1.0.0-beta.33"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rigoblock/protocol",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "dist/contracts.js",
   "scripts": {
     "build": "npm run compile && rm -rf dist && lerna run --scope=@rigoblock/dapp ganache:bootstrap && webpack",
@@ -62,7 +62,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.54",
     "@babel/polyfill": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
-    "@rigoblock/deployer": "^0.1.1",
+    "@rigoblock/deployer": "^0.1.2",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^23.4.0",
     "babel-loader": "^8.0.0-beta",


### PR DESCRIPTION
 - @rigoblock/api@0.2.4
 - @rigoblock/dapp@0.1.9
 - @rigoblock/deployer@0.1.2
 - @rigoblock/ganache-bootstrap@0.1.11
 - @rigoblock/protocol@0.2.8


#### :notebook: Overview
- Published new version of rigoblock protocol now correctly transpiled by Babel, no more spread operator in dist files.
