### PR TITLE
Rollback logout logic

### DIFF
--- a/packages/dapp/src/epics/routing/logout.js
+++ b/packages/dapp/src/epics/routing/logout.js
@@ -1,16 +1,33 @@
 import 'rxjs/add/operator/filter'
 import 'rxjs/add/operator/mergeMap'
+import * as ROUTES from '../../constants/routes'
+import { LOCATION_CHANGE } from 'react-router-redux'
+import { empty } from 'rxjs/observable/empty'
+import { merge } from 'rxjs/observable/merge'
 import { of } from 'rxjs/observable/of'
 import blockChainActions from '../../actions/blockchain-actions'
 import routerActions from '../../actions/router-actions'
 
-const logoutEpic = action$ =>
-  action$
+const logoutEpic = (action$, store) => {
+  const action$1 = action$
     .filter(
       action =>
         action.type === blockChainActions.blockChainLogout.getType() ||
         action.type === blockChainActions.blockChainError.getType()
     )
     .mergeMap(() => of(routerActions.logout()))
+
+  const action$2 = action$
+    .filter(action => action.type === LOCATION_CHANGE)
+    .mergeMap(() => {
+      const state = store.getState()
+      return (!state.preferences.currentAccount || state.globalReducer.error) &&
+        state.routing.location.pathname !== ROUTES.LOGIN
+        ? of(routerActions.logout())
+        : empty()
+    })
+
+  return merge(action$1, action$2)
+}
 
 export default logoutEpic

--- a/packages/dapp/src/epics/routing/logout.test.js
+++ b/packages/dapp/src/epics/routing/logout.test.js
@@ -1,5 +1,6 @@
 import * as ROUTES from '../../constants/routes'
 import { ActionsObservable } from 'redux-observable'
+import { LOCATION_CHANGE } from 'react-router-redux'
 import { TestScheduler } from 'rxjs'
 import blockChainActions from '../../actions/blockchain-actions'
 import logoutEpic from './logout'
@@ -7,6 +8,7 @@ import routerActions from '../../actions/router-actions'
 
 describe('logout Epic', () => {
   const testError = new Error('test error')
+  const locationChangeAction = () => ({ type: LOCATION_CHANGE })
   const loggedOutState = {
     preferences: {
       currentAccount: null,
@@ -58,6 +60,27 @@ describe('logout Epic', () => {
       expect(actual).toEqual(expected)
     })
 
+    const action$ = new ActionsObservable(
+      ts.createHotObservable(inputMarble, inputValues)
+    )
+    const outputAction = logoutEpic(action$, mockStore)
+
+    ts.expectObservable(outputAction).toBe(expectedMarble, expectedValues)
+    ts.flush()
+  })
+  it('redirects the user to login page if user is not logged and location change action is fired', () => {
+    getStateMock.mockReturnValue(loggedOutState)
+    const inputValues = {
+      a: locationChangeAction()
+    }
+    const expectedValues = {
+      b: routerActions.logout()
+    }
+    const inputMarble = 'a'
+    const expectedMarble = 'b'
+    const ts = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
     const action$ = new ActionsObservable(
       ts.createHotObservable(inputMarble, inputValues)
     )


### PR DESCRIPTION
resolves #327

#### :notebook: Overview
- Rolled back Logout logic that we removed in a previous PR that won't allow us to navigate between pages if we are not logged in.
