### PR TITLE
remove empty list getter

### DIFF
--- a/packages/protocol/solidity-contracts/Authority/Authority.sol
+++ b/packages/protocol/solidity-contracts/Authority/Authority.sol
@@ -38,7 +38,6 @@ contract Authority is Owned, AuthorityFace {
 
     struct Type {
         string types;
-        mapping (string=> address[]) mapFromGroup;
         List[] list;
     }
 
@@ -322,16 +321,6 @@ contract Authority is Owned, AuthorityFace {
         returns (address)
     {
         return blocks.exchangesAuthority;
-    }
-
-    /// @dev Provides an array of addresses for a group
-    /// @param _group Address of the group/factory
-    /// @return Array of addresses of the pools for a specific group
-    function getListsByGroups(string _group)
-        external view
-        returns (address[])
-    {
-        return types.mapFromGroup[_group];
     }
 
     // INTERNAL FUNCTIONS

--- a/packages/protocol/solidity-contracts/Authority/AuthorityFace.sol
+++ b/packages/protocol/solidity-contracts/Authority/AuthorityFace.sol
@@ -60,5 +60,4 @@ interface AuthorityFace {
     function getVaultEventful() external view returns (address);
     function getNavVerifier() external view returns (address);
     function getExchangesAuthority() external view returns (address);
-    function getListsByGroups(string _group) external view returns (address[]);
 }

--- a/packages/protocol/solidity-contracts/exchanges/ExchangesAuthority/ExchangesAuthority.sol
+++ b/packages/protocol/solidity-contracts/exchanges/ExchangesAuthority/ExchangesAuthority.sol
@@ -37,7 +37,6 @@ contract ExchangesAuthority is Owned, ExchangesAuthorityFace {
 
     struct Type {
         string types;
-        mapping (string=> address[]) mapFromGroup;
         List[] list;
     }
 
@@ -377,16 +376,6 @@ contract ExchangesAuthority is Owned, ExchangesAuthorityFace {
         returns (address)
     {
         return blocks.casper;
-    }
-
-    /// @dev Provides an array of addresses for a group
-    /// @param _group Address of the group/factory
-    /// @return Array of addresses of the pools for a specific group
-    function getListsByGroups(string _group)
-        external view
-        returns (address[])
-    {
-        return types.mapFromGroup[_group];
     }
 
     // INTERNAL FUNCTIONS

--- a/packages/protocol/solidity-contracts/exchanges/ExchangesAuthority/ExchangesAuthorityFace.sol
+++ b/packages/protocol/solidity-contracts/exchanges/ExchangesAuthority/ExchangesAuthorityFace.sol
@@ -206,11 +206,4 @@ interface ExchangesAuthorityFace {
     function getCasper()
         external view
         returns (address);
-
-    /// @dev Provides an array of addresses for a group
-    /// @param _group Address of the group/factory
-    /// @return Array of addresses of the pools for a specific group
-    function getListsByGroups(string _group)
-        external view
-        returns (address[]);
 }


### PR DESCRIPTION

#### :notebook: Overview

removed an unused function which used to return an array, but was deprecated and now just returned an empty array