### PR TITLE
Use separate processes on bull

### DIFF
--- a/packages/stats/src/tasks/index.ts
+++ b/packages/stats/src/tasks/index.ts
@@ -1,13 +1,7 @@
-import calculateBalance from './calculateBalance'
-import calculateEthBalance from './calculateEthBalance'
-import fetchDragos from './fetchDragos'
-import getSharePrice from './getSharePrice'
-import getTotalSupply from './getTotalSupply'
-
 export default {
-  calculateBalance,
-  fetchDragos,
-  getTotalSupply,
-  getSharePrice,
-  calculateEthBalance
+  calculateBalance: __dirname + '/calculateBalance.js',
+  fetchDragos: __dirname + '/fetchDragos.js',
+  getTotalSupply: __dirname + '/getTotalSupply.js',
+  getSharePrice: __dirname + '/getSharePrice.js',
+  calculateEthBalance: __dirname + '/calculateEthBalance.js'
 }


### PR DESCRIPTION
resolves #412

#### :notebook: Overview
- The `task` folder now export a map with the absolute urls of the various task. This allows Bull to spawn a separate process per queue, which should allow it to continue operating normally in case one of the queues crashes.

#### :warning: Dependencies (optional)
-  These are currently a few open issues on the Bull repository as users are reporting a huge number of processes being spawned and eating all of the memory. We are waiting for the issue/bug to be resolved before implementing this feature.
Links to the bull issues: 
https://github.com/OptimalBits/bull/issues/923
https://github.com/OptimalBits/bull/issues/1008