### PR TITLE
Bugfix - Protocol package build

### DIFF
--- a/packages/protocol/solidity-contracts/Drago/Drago.sol
+++ b/packages/protocol/solidity-contracts/Drago/Drago.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { AuthorityFace as Authority } from "../Authority/AuthorityFace.sol";

--- a/packages/protocol/solidity-contracts/DragoFactory/DragoFactory.sol
+++ b/packages/protocol/solidity-contracts/DragoFactory/DragoFactory.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { DragoRegistryFace as DragoRegistry } from "../Registry/DragoRegistryFace.sol";

--- a/packages/protocol/solidity-contracts/RigoToken/ProofOfPerformance/ProofOfPerformance.sol
+++ b/packages/protocol/solidity-contracts/RigoToken/ProofOfPerformance/ProofOfPerformance.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { PoolFace as Pool } from "../../utils/Pool/PoolFace.sol";

--- a/packages/protocol/solidity-contracts/exchanges/adapters/AEthfinex.sol
+++ b/packages/protocol/solidity-contracts/exchanges/adapters/AEthfinex.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { WrapperLock as TokenWrapper } from "../../utils/tokens/WrapperLock/WrapperLock.sol";

--- a/packages/protocol/solidity-contracts/exchanges/adapters/AWeth.sol
+++ b/packages/protocol/solidity-contracts/exchanges/adapters/AWeth.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { Drago } from "../../Drago/Drago.sol";


### PR DESCRIPTION
#### :notebook: Overview
- Removed apex from pragma solidity version of the following contracts: 
`Aethfinex`, `Aweth`, `Drago`, `DragoFactory`, `ProofOfPerformance`

These contracts were requiring the contracts `WrapperLockEth` and `ReentrancyGuard` as dependencies, which require pragma solidity 0.4.24. Because of the apex ^, deployer was trying to compile them with solidity 0.4.25, causing an error.