### PR TITLE
Bugfix: snapshot test failing on Master

### DIFF
--- a/packages/dapp/src/components/organisms/PreferencesForm/__snapshots__/PreferencesForm.test.js.snap
+++ b/packages/dapp/src/components/organisms/PreferencesForm/__snapshots__/PreferencesForm.test.js.snap
@@ -287,8 +287,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                       "GMT +10:30",
                       "GMT +11:00",
                       "GMT +12:00",
-                      "GMT +12:45",
                       "GMT +13:00",
+                      "GMT +13:45",
                       "GMT +14:00",
                     ],
                   }
@@ -353,8 +353,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                         "GMT +10:30",
                         "GMT +11:00",
                         "GMT +12:00",
-                        "GMT +12:45",
                         "GMT +13:00",
+                        "GMT +13:45",
                         "GMT +14:00",
                       ]
                     }
@@ -510,8 +510,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                           "GMT +10:30",
                           "GMT +11:00",
                           "GMT +12:00",
-                          "GMT +12:45",
                           "GMT +13:00",
+                          "GMT +13:45",
                           "GMT +14:00",
                         ]
                       }
@@ -672,8 +672,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                             "GMT +10:30",
                             "GMT +11:00",
                             "GMT +12:00",
-                            "GMT +12:45",
                             "GMT +13:00",
+                            "GMT +13:45",
                             "GMT +14:00",
                           ]
                         }
@@ -733,8 +733,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                               "GMT +10:30",
                               "GMT +11:00",
                               "GMT +12:00",
-                              "GMT +12:45",
                               "GMT +13:00",
+                              "GMT +13:45",
                               "GMT +14:00",
                             ]
                           }
@@ -822,8 +822,8 @@ exports[`PreferencesForm component renders correctly 1`] = `
                                 "GMT +10:30",
                                 "GMT +11:00",
                                 "GMT +12:00",
-                                "GMT +12:45",
                                 "GMT +13:00",
+                                "GMT +13:45",
                                 "GMT +14:00",
                               ]
                             }

--- a/packages/exchange-connector/package.json
+++ b/packages/exchange-connector/package.json
@@ -54,7 +54,6 @@
     ]
   },
   "jest": {
-    "verbose": true,
     "testURL": "http://localhost/",
     "roots": [
       "<rootDir>/src"


### PR DESCRIPTION
#### :notebook: Overview
- Updated snapshot
- removed `verbose: true` from exchange-connector tests, so unit test console output is more concise
