### PR TITLE
Change location of InfluxDB data folder on docker

### DIFF
--- a/packages/stats/docker-compose.prod.yml
+++ b/packages/stats/docker-compose.prod.yml
@@ -35,7 +35,7 @@ services:
     env_file:
       - 'env.influxdb'
     volumes:
-      - ~/data/influxdb:/var/lib/influxdb
+      - /stats-data/influxdb:/var/lib/influxdb
 
   telegraf:
     image: telegraf:latest
@@ -65,7 +65,7 @@ services:
     links:
       - influxdb
     volumes:
-      - ~/data/chronograf:/var/lib/chronograf
+      - /stats-data/chronograf:/var/lib/chronograf
     labels:
       traefik.backend: "chronograf"
       traefik.enable: "true"


### PR DESCRIPTION
#### :notebook: Overview
- InfluxDB's `Data` folder not saved anymore under @vshjxyz user but under a specific `/stats-data` folder