### PR TITLE
Roll back generated README

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,65 +1,45 @@
+# API
 
-API
-===
-
-Building the package
---------------------
+## Building the package
 
 Start Ganache
-
 ```
 lerna run --scope @rigoblock/dapp ganache --stream
 ```
-
 Then run the following command:
-
 ```
 yarn build
 ```
 
-Available Scripts
------------------
+## Available Scripts
 
 ### From the project root you can run:
-
 ```
 yarn lint
 ```
-
 Lints all files.
-
 ```
 yarn abi-extract
 ```
-
 Extracts all abis of the deployed contracts, then copies them over to the .tmp folder in json format. Requires Ganache to be running.
-
 ```
 yarn abi-gen
 ```
-
 Generates contract wrappers from the abi JSON files.
-
 ```
 yarn tsc
 ```
-
 Compiles all .ts files to Javascript, including map and declaration files into the `dist` folder.
-
 ```
 yarn tsc:watch
 ```
-
 Compiles on watch mode
-
 ```
 yarn build
 ```
-
 Extracts abis saving them as JSON files, generates wrappers and compiles .ts files into `dist` folder. Requires Ganache to be running unless abi files have been saved previously.
 
-Initialising the API
---------------------
+## Initialising the API
 
 ```javascript
 import Api from '@rigoblock/api'
@@ -67,11 +47,9 @@ import Api from '@rigoblock/api'
 const api = new Api()
 await api.init(web3, rpcUrl)
 ```
-
 `rpcUrl` is optional and defaults to `ws://localhost:8545` to work with Ganache.
 
-Instantiating contracts
------------------------
+## Instantiating contracts
 
 To instantiate a contract we use the `createAndValidate()` function, which will check if the contract is deployed on the blockChain, throwing an error if it isn't. The function accepts two parameters: a web3 instance and the contract's address.
 
@@ -86,11 +64,9 @@ const authority = await api.contract.Authority.createAndValidate(
 )
 ```
 
-Calling methods
----------------
+## Calling methods
 
 ### Example
-
 Creating a Vault from the VaultFactory contract
 
 ```javascript
@@ -114,16 +90,13 @@ const receipt = await txObject.send({
 
 const vaultAddress = receipt.events.VaultCreated.returnValues.vault
 ```
-
 We add some more gas to the estimate as it can be incorrect in case new blocks are added between the estimate and the actual transaction taking place.
 
-Adding custom methods
----------------------
+## Adding custom methods
 
 Custom methods can be added to our contracts using the [Handlebars template](template.handlebars).
 
-Events
-------
+## Events
 
 To get past events of a contract, use the `getPastEvents` function. To create a subscription to a single event, use the relative method and pass it a callback to retrieve the data.
 
@@ -144,7 +117,6 @@ await vaultFactory.VaultCreatedEvent(
 If we wish to listen for all events, use the `allEvents` method.
 
 ### Example
-
 ```javascript
 await vaultFactory.allEvents(
   {
@@ -154,47 +126,3 @@ await vaultFactory.allEvents(
   (err, events) => (err ? console.error(err) : console.log(events))
 )
 ```
-
-## Index
-
-### External modules
-
-* ["api"](docs/modules/_api_.md)
-* ["constants"](docs/modules/_constants_.md)
-* ["contracts/baseContract"](docs/modules/_contracts_basecontract_.md)
-* ["contracts/contract"](docs/modules/_contracts_contract_.md)
-* ["contracts/contractsList"](docs/modules/_contracts_contractslist_.md)
-* ["contracts/models/a_ethfinex"](docs/modules/_contracts_models_a_ethfinex_.md)
-* ["contracts/models/a_weth"](docs/modules/_contracts_models_a_weth_.md)
-* ["contracts/models/authority"](docs/modules/_contracts_models_authority_.md)
-* ["contracts/models/distribution"](docs/modules/_contracts_models_distribution_.md)
-* ["contracts/models/drago"](docs/modules/_contracts_models_drago_.md)
-* ["contracts/models/drago_eventful"](docs/modules/_contracts_models_drago_eventful_.md)
-* ["contracts/models/drago_factory"](docs/modules/_contracts_models_drago_factory_.md)
-* ["contracts/models/drago_registry"](docs/modules/_contracts_models_drago_registry_.md)
-* ["contracts/models/erc20"](docs/modules/_contracts_models_erc20_.md)
-* ["contracts/models/exchange_efx"](docs/modules/_contracts_models_exchange_efx_.md)
-* ["contracts/models/exchange_v1_fork"](docs/modules/_contracts_models_exchange_v1_fork_.md)
-* ["contracts/models/exchanges_authority"](docs/modules/_contracts_models_exchanges_authority_.md)
-* ["contracts/models/faucet"](docs/modules/_contracts_models_faucet_.md)
-* ["contracts/models/inflation"](docs/modules/_contracts_models_inflation_.md)
-* ["contracts/models/migrations"](docs/modules/_contracts_models_migrations_.md)
-* ["contracts/models/nav_verifier"](docs/modules/_contracts_models_nav_verifier_.md)
-* ["contracts/models/owned"](docs/modules/_contracts_models_owned_.md)
-* ["contracts/models/owned_uninitialized"](docs/modules/_contracts_models_owned_uninitialized_.md)
-* ["contracts/models/proof_of_performance"](docs/modules/_contracts_models_proof_of_performance_.md)
-* ["contracts/models/rigo_token"](docs/modules/_contracts_models_rigo_token_.md)
-* ["contracts/models/sig_verifier"](docs/modules/_contracts_models_sig_verifier_.md)
-* ["contracts/models/token_transfer_proxy"](docs/modules/_contracts_models_token_transfer_proxy_.md)
-* ["contracts/models/unlimited_allowance_token"](docs/modules/_contracts_models_unlimited_allowance_token_.md)
-* ["contracts/models/vault"](docs/modules/_contracts_models_vault_.md)
-* ["contracts/models/vault_eventful"](docs/modules/_contracts_models_vault_eventful_.md)
-* ["contracts/models/vault_factory"](docs/modules/_contracts_models_vault_factory_.md)
-* ["contracts/models/weth9"](docs/modules/_contracts_models_weth9_.md)
-* ["contracts/models/wrapper_lock"](docs/modules/_contracts_models_wrapper_lock_.md)
-* ["contracts/models/wrapper_lock_eth"](docs/modules/_contracts_models_wrapper_lock_eth_.md)
-* ["index"](docs/modules/_index_.md)
-* ["webSocketSubprovider"](docs/modules/_websocketsubprovider_.md)
-
----
-

--- a/packages/api/doc-gen.js
+++ b/packages/api/doc-gen.js
@@ -6,9 +6,6 @@ const fetchContracts = require('@rigoblock/contracts').default
 const glob = promisify(require('glob'))
 const exec = promisify(require('child_process').exec)
 
-const unlink = promisify(fs.unlink)
-const symlink = promisify(fs.symlink)
-const copyFile = promisify(fs.copyFile)
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
@@ -20,10 +17,6 @@ function capitalize(string) {
 }
 
 const docGen = async networkId => {
-  console.log('Renaming readme...')
-  await unlink('./README.md')
-  await copyFile('./README_BASE.md', './README.md')
-
   // TODO: do this call programmatically as soon
   // as there's a clear way for TypeDoc to be run from node
   console.log('Launching TypeDoc...')
@@ -36,18 +29,6 @@ const docGen = async networkId => {
       `--out docs src`
     ].join(' ')
   )
-
-  console.log('Recreating readme...')
-  await unlink('./README.md')
-
-  const linkRegExp = /(?<=\().*\.md(?=\))/g
-  let readmeContent = (await readFile('./docs/README.md')).toString()
-  const links = readmeContent.match(linkRegExp)
-  links.map(
-    link => (readmeContent = readmeContent.replace(link, `docs/${link}`))
-  )
-  await writeFile('./README.md', readmeContent)
-  await unlink('./docs/README.md')
 
   const contractsMap = await fetchContracts(networkId)
   const docsList = await glob('./docs/**/*.md')

--- a/packages/api/docs/README.md
+++ b/packages/api/docs/README.md
@@ -1,45 +1,65 @@
-# API
 
-## Building the package
+API
+===
+
+Building the package
+--------------------
 
 Start Ganache
+
 ```
 lerna run --scope @rigoblock/dapp ganache --stream
 ```
+
 Then run the following command:
+
 ```
 yarn build
 ```
 
-## Available Scripts
+Available Scripts
+-----------------
 
 ### From the project root you can run:
+
 ```
 yarn lint
 ```
+
 Lints all files.
+
 ```
 yarn abi-extract
 ```
+
 Extracts all abis of the deployed contracts, then copies them over to the .tmp folder in json format. Requires Ganache to be running.
+
 ```
 yarn abi-gen
 ```
+
 Generates contract wrappers from the abi JSON files.
+
 ```
 yarn tsc
 ```
+
 Compiles all .ts files to Javascript, including map and declaration files into the `dist` folder.
+
 ```
 yarn tsc:watch
 ```
+
 Compiles on watch mode
+
 ```
 yarn build
 ```
+
 Extracts abis saving them as JSON files, generates wrappers and compiles .ts files into `dist` folder. Requires Ganache to be running unless abi files have been saved previously.
 
-## Initialising the API
+Initialising the API
+--------------------
 
 ```javascript
 import Api from '@rigoblock/api'
@@ -47,9 +67,11 @@ import Api from '@rigoblock/api'
 const api = new Api()
 await api.init(web3, rpcUrl)
 ```
+
 `rpcUrl` is optional and defaults to `ws://localhost:8545` to work with Ganache.
 
-## Instantiating contracts
+Instantiating contracts
+-----------------------
 
 To instantiate a contract we use the `createAndValidate()` function, which will check if the contract is deployed on the blockChain, throwing an error if it isn't. The function accepts two parameters: a web3 instance and the contract's address.
 
@@ -64,9 +86,11 @@ const authority = await api.contract.Authority.createAndValidate(
 )
 ```
 
-## Calling methods
+Calling methods
+---------------
 
 ### Example
+
 Creating a Vault from the VaultFactory contract
 
 ```javascript
@@ -90,13 +114,16 @@ const receipt = await txObject.send({
 
 const vaultAddress = receipt.events.VaultCreated.returnValues.vault
 ```
+
 We add some more gas to the estimate as it can be incorrect in case new blocks are added between the estimate and the actual transaction taking place.
 
-## Adding custom methods
+Adding custom methods
+---------------------
 
 Custom methods can be added to our contracts using the [Handlebars template](template.handlebars).
 
-## Events
+Events
+------
 
 To get past events of a contract, use the `getPastEvents` function. To create a subscription to a single event, use the relative method and pass it a callback to retrieve the data.
 
@@ -117,6 +144,7 @@ await vaultFactory.VaultCreatedEvent(
 If we wish to listen for all events, use the `allEvents` method.
 
 ### Example
+
 ```javascript
 await vaultFactory.allEvents(
   {
@@ -126,3 +154,47 @@ await vaultFactory.allEvents(
   (err, events) => (err ? console.error(err) : console.log(events))
 )
 ```
+
+## Index
+
+### External modules
+
+* ["api"](modules/_api_.md)
+* ["constants"](modules/_constants_.md)
+* ["contracts/baseContract"](modules/_contracts_basecontract_.md)
+* ["contracts/contract"](modules/_contracts_contract_.md)
+* ["contracts/contractsList"](modules/_contracts_contractslist_.md)
+* ["contracts/models/a_ethfinex"](modules/_contracts_models_a_ethfinex_.md)
+* ["contracts/models/a_weth"](modules/_contracts_models_a_weth_.md)
+* ["contracts/models/authority"](modules/_contracts_models_authority_.md)
+* ["contracts/models/distribution"](modules/_contracts_models_distribution_.md)
+* ["contracts/models/drago"](modules/_contracts_models_drago_.md)
+* ["contracts/models/drago_eventful"](modules/_contracts_models_drago_eventful_.md)
+* ["contracts/models/drago_factory"](modules/_contracts_models_drago_factory_.md)
+* ["contracts/models/drago_registry"](modules/_contracts_models_drago_registry_.md)
+* ["contracts/models/erc20"](modules/_contracts_models_erc20_.md)
+* ["contracts/models/exchange_efx"](modules/_contracts_models_exchange_efx_.md)
+* ["contracts/models/exchange_v1_fork"](modules/_contracts_models_exchange_v1_fork_.md)
+* ["contracts/models/exchanges_authority"](modules/_contracts_models_exchanges_authority_.md)
+* ["contracts/models/faucet"](modules/_contracts_models_faucet_.md)
+* ["contracts/models/inflation"](modules/_contracts_models_inflation_.md)
+* ["contracts/models/migrations"](modules/_contracts_models_migrations_.md)
+* ["contracts/models/nav_verifier"](modules/_contracts_models_nav_verifier_.md)
+* ["contracts/models/owned"](modules/_contracts_models_owned_.md)
+* ["contracts/models/owned_uninitialized"](modules/_contracts_models_owned_uninitialized_.md)
+* ["contracts/models/proof_of_performance"](modules/_contracts_models_proof_of_performance_.md)
+* ["contracts/models/rigo_token"](modules/_contracts_models_rigo_token_.md)
+* ["contracts/models/sig_verifier"](modules/_contracts_models_sig_verifier_.md)
+* ["contracts/models/token_transfer_proxy"](modules/_contracts_models_token_transfer_proxy_.md)
+* ["contracts/models/unlimited_allowance_token"](modules/_contracts_models_unlimited_allowance_token_.md)
+* ["contracts/models/vault"](modules/_contracts_models_vault_.md)
+* ["contracts/models/vault_eventful"](modules/_contracts_models_vault_eventful_.md)
+* ["contracts/models/vault_factory"](modules/_contracts_models_vault_factory_.md)
+* ["contracts/models/weth9"](modules/_contracts_models_weth9_.md)
+* ["contracts/models/wrapper_lock"](modules/_contracts_models_wrapper_lock_.md)
+* ["contracts/models/wrapper_lock_eth"](modules/_contracts_models_wrapper_lock_eth_.md)
+* ["index"](modules/_index_.md)
+* ["webSocketSubprovider"](modules/_websocketsubprovider_.md)
+
+---
+


### PR DESCRIPTION
#### :notebook: Overview

- rollback to keeping the generated README in the docs folder, to be pointed at in our documentation site, while the `README_BASE` becomes `README` and is the one used by Github.
