### PR TITLE
Allow API to work without window.web3

### DIFF
--- a/packages/api/prova.js
+++ b/packages/api/prova.js
@@ -1,0 +1,18 @@
+const Web3 = require('web3')
+const Api = require('./dist/api').default
+
+const ads = async () => {
+  const web3 = new Web3(
+    new Web3.providers.WebsocketProvider('wss://ropsten.infura.io/ws/')
+  )
+  const api = new Api()
+  await api.init(web3)
+
+  const authority = await api.contract.Authority.createAndValidate(
+    api.web3,
+    api.contract.Authority.address
+  )
+  console.log(authority)
+}
+
+ads()

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -52,9 +52,13 @@ class Api {
    */
   async init(web3: Web3 = window['web3']) {
     const networkPromise: Promise<number> = new Promise((resolve, reject) => {
-      window['web3'].version.getNetwork((err, res) =>
-        err ? reject(err) : resolve(res)
-      )
+      if (web3.version['getNetwork']) {
+        web3.version['getNetwork']((err, res) =>
+          err ? reject(err) : resolve(res)
+        )
+      } else {
+        web3.eth.net.getId((err, id) => (err ? reject(err) : resolve(id)))
+      }
     })
     const networkId = await networkPromise
     const rpcUrl = RPC_URLS[networkId]

--- a/packages/api/src/contracts/contractsList.ts
+++ b/packages/api/src/contracts/contractsList.ts
@@ -54,8 +54,7 @@ export abstract class ContractsList {
   RigoToken: typeof RigoToken & RigoToken
   SigVerifier: typeof SigVerifier & SigVerifier
   TokenTransferProxy: typeof TokenTransferProxy & TokenTransferProxy
-  UnlimitedAllowanceToken: typeof UnlimitedAllowanceToken &
-    UnlimitedAllowanceToken
+  UnlimitedAllowanceToken: typeof UnlimitedAllowanceToken & UnlimitedAllowanceToken
   Vault: typeof Vault & Vault
   VaultEventful: typeof VaultEventful & VaultEventful
   VaultFactory: typeof VaultFactory & VaultFactory


### PR DESCRIPTION
#### :notebook: Overview

- minor fix to the API to now work correctly if the `api.init()` function is passed a web3 1.0 instance instead of the 0.20 window.web3 injected by Metamask.
