### PR TITLE
Fix contracts package dependencies

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,7 +14,8 @@
   "files": [
     "artifacts",
     "deploy",
-    "dist"
+    "dist",
+    "constants"
   ],
   "config": {
     "mnemonic": "lemon scrub wasp bracket town boat property sadness layer taxi butter audit"
@@ -58,6 +59,16 @@
       }
     }
   },
+  "dependencies": {
+    "@rigoblock/deployer": "^0.1.13",
+    "chalk": "^2.4.1",
+    "inquirer": "^6.2.1",
+    "multispinner": "^0.2.1",
+    "path": "^0.12.7",
+    "pino": "^4.17.3",
+    "truffle-hdwallet-provider": "^0.0.6",
+    "web3": "1.0.0-beta.36"
+  },
   "devDependencies": {
     "0x.js": "^0.38.6",
     "@babel/core": "^7.0.0-beta.54",
@@ -65,22 +76,16 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.54",
     "@babel/polyfill": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
-    "@rigoblock/deployer": "^0.1.13",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "23.4.2",
     "babel-loader": "^8.0.0-beta",
     "bignumber.js": "^7.2.1",
-    "chalk": "^2.4.1",
     "eslint": "^5.6.0",
     "fs-extra": "^7.0.0",
     "ganache-cli": "^6.1.8",
     "jest": "23.4.1",
     "jest-extended": "^0.11.0",
-    "multispinner": "^0.2.1",
-    "pino": "^4.17.3",
     "solhint": "^1.2.1",
-    "truffle-hdwallet-provider": "^0.0.6",
-    "web3": "1.0.0-beta.36",
     "webpack": "^4.16.3",
     "webpack-cli": "^3.1.0"
   }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -60,6 +60,7 @@
     }
   },
   "dependencies": {
+    "@babel/polyfill": "^7.0.0-beta.54",
     "@rigoblock/deployer": "^0.1.13",
     "chalk": "^2.4.1",
     "inquirer": "^6.2.1",
@@ -74,7 +75,6 @@
     "@babel/core": "^7.0.0-beta.54",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.54",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.54",
-    "@babel/polyfill": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "23.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,6 +2382,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -9095,6 +9100,25 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+inquirer@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
+  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.0.0"
+    through "^2.3.6"
+
 internal-ip@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-1.2.0.tgz#ae9fbf93b984878785d50a8de1b356956058cf5c"
@@ -12710,6 +12734,14 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
@@ -13348,7 +13380,7 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
@@ -15858,6 +15890,13 @@ strip-ansi@4.0.0, strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+  dependencies:
+    ansi-regex "^4.0.0"
 
 strip-ansi@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
resolves #647

#### :notebook: Overview

- Added correct dependencies to the `@rigoblock/contracts` package.
- Included the `constants` folder to our package so our deploy scripts can work.
