### PR TITLE
add method to return pools by caller

### DIFF
--- a/packages/contracts/src/examples/helpers/HGetDragoData.sol
+++ b/packages/contracts/src/examples/helpers/HGetDragoData.sol
@@ -97,7 +97,7 @@ interface DragoRegistryFace {
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 contract HGetDragoData {
-    
+
     struct DragoData {
         string name;
         string symbol;
@@ -119,7 +119,7 @@ contract HGetDragoData {
      * CONSTANT PUBLIC FUNCTIONS
      */
     /// @dev Returns structs of infos on a drago from its ID.
-    /// @param _dragoRegistry Address of the target drago.
+    /// @param _dragoRegistry Address of the pools registry.
     /// @param _dragoId Number of the target drago ID.
     /// @return Structs of data.
     function queryDataFromId(
@@ -142,7 +142,8 @@ contract HGetDragoData {
     }
 
     /// @dev Returns structs of infos on a drago from its address.
-    /// @param _dragoAddress Array of addresses of the target dragos.
+    /// @param _dragoRegistry Address of the pools registry.
+    /// @param _dragoAddress Array of addresses of the target drago.
     /// @return Arrays of structs of data.
     function queryDataFromAddress(
         address _dragoRegistry,
@@ -194,6 +195,7 @@ contract HGetDragoData {
     }
 
     /// @dev Returns structs of infos on a drago from its address.
+    /// @param _dragoRegistry Address of the pools registry.
     /// @param _dragoAddresses Array of addresses of the target dragos.
     /// @return Arrays of structs of data and related address of a drago.
     function queryMultiDataFromAddress(

--- a/packages/contracts/src/examples/helpers/HGetPools.sol
+++ b/packages/contracts/src/examples/helpers/HGetPools.sol
@@ -16,18 +16,73 @@
 
 */
 
-pragma solidity 0.5.0;
+pragma solidity 0.5.2;
 pragma experimental ABIEncoderV2;
 
-import { DragoRegistryFace } from "../../protocol/DragoRegistry/DragoRegistryFace.sol";
+/// @title Drago Registry Interface - Allows external interaction with Drago Registry.
+/// @author Gabriele Rigo - <gab@rigoblock.com>
+// solhint-disable-next-line
+interface DragoRegistryFace {
+
+    /*
+     * CORE FUNCTIONS
+     */
+    function register(address _drago, string calldata _name, string calldata _symbol, uint256 _dragoId, address _owner) external payable returns (bool);
+    function unregister(uint256 _id) external;
+    function setMeta(uint256 _id, bytes32 _key, bytes32 _value) external;
+    function addGroup(address _group) external;
+    function setFee(uint256 _fee) external;
+    function updateOwner(uint256 _id) external;
+    function updateOwners(uint256[] calldata _id) external;
+    function upgrade(address _newAddress) external payable; //payable as there is a transfer of value, otherwise opcode might throw an error
+    function setUpgraded(uint256 _version) external;
+    function drain() external;
+
+    /*
+     * CONSTANT PUBLIC FUNCTIONS
+     */
+    function dragoCount() external view returns (uint256);
+    function fromId(uint256 _id) external view returns (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
+    function fromAddress(address _drago) external view returns (uint256 id, string memory name, string memory symbol, uint256 dragoId, address owner, address group);
+    function fromName(string calldata _name) external view returns (uint256 id, address drago, string memory symbol, uint256 dragoId, address owner, address group);
+    function getNameFromAddress(address _pool) external view returns (string memory);
+    function getSymbolFromAddress(address _pool) external view returns (string memory);
+    function meta(uint256 _id, bytes32 _key) external view returns (bytes32);
+    function getGroups() external view returns (address[] memory);
+    function getFee() external view returns (uint256);
+}
 
 /// @title Multiple Balances Helper - Allows to receive a list of pools for a specific group.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 contract HGetPools {
+    
+    struct DragoData {
+        string name;
+        string symbol;
+        uint256 sellPrice;
+        uint256 buyPrice;
+        address owner;
+        address feeCollector;
+        address dragoDao;
+        uint256 ratio;
+        uint256 transactionFee;
+        uint256 totalSupply;
+        uint256 ethBalance;
+        uint32 minPeriod;
+        uint256 id;
+        address drago;
+    }
 
+    /*
+     * CONSTANT PUBLIC FUNCTIONS
+     */
+    /// @dev Returns structs of infos on a list of dragos for a group.
+    /// @param _dragoRegistry Address of the pools registry.
+    /// @param _group Number of the target drago group.
+    /// @return Arrays of structs of data and related address of a drago.
     function queryAllPoolsByGroup(
-        address _registry,
+        address _dragoRegistry,
         address _group)
         external
         view
@@ -36,24 +91,24 @@ contract HGetPools {
             string[]  memory names,
             string[]  memory symbols,
             uint256[]  memory dragoIds,
-            address[]  memory owners
+            address[] memory owners
         )
     {
-        DragoRegistryFace registry = DragoRegistryFace(_registry);
-        uint256 length = registry.dragoCount();
+        DragoRegistryFace dragoRegistryInstance = DragoRegistryFace(_dragoRegistry);
+        uint256 length = dragoRegistryInstance.dragoCount();
+        address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group) = registry.fromId(i);
-            if (group != _group) continue;
-            dragos[i] = drago;
-            names[i] = name;
-            symbols[i] = symbol;
-            dragoIds[i] = dragoId;
-            owners[i] = owner;
+            (dragos[i], names[i], symbols[i], dragoIds[i], owners[i], groups[i]) = dragoRegistryInstance.fromId(i);
+            if (groups[i] != _group) continue;
         }
     }
     
+    /// @dev Returns structs of infos on a list of dragos for a group.
+    /// @param _dragoRegistry Address of the pools registry.
+    /// @param _group Number of the target drago group.
+    /// @return Arrays of structs of data and related address of a drago.
     function queryAllPoolsByCaller(
-        address _registry,
+        address _dragoRegistry,
         address _group)
         external
         view
@@ -61,20 +116,16 @@ contract HGetPools {
             address[] memory dragos,
             string[]  memory names,
             string[]  memory symbols,
-            uint256[]  memory dragoIds,
-            address[]  memory owners
+            uint256[]  memory dragoIds
         )
     {
-        DragoRegistryFace registry = DragoRegistryFace(_registry);
-        uint256 length = registry.dragoCount();
+        DragoRegistryFace dragoRegistryInstance = DragoRegistryFace(_dragoRegistry);
+        uint256 length = dragoRegistryInstance.dragoCount();
+        address[] memory owners = new address[](length);
+        address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group) = registry.fromId(i);
-            if (owner != address(msg.sender) || group != _group) continue;
-            dragos[i] = drago;
-            names[i] = name;
-            symbols[i] = symbol;
-            dragoIds[i] = dragoId;
-            owners[i] = owner;
+            (dragos[i], names[i], symbols[i], dragoIds[i], owners[i], groups[i]) = dragoRegistryInstance.fromId(i);
+            if (owners[i] != address(msg.sender) || groups[i] != _group) continue;
         }
     }
 }

--- a/packages/contracts/src/examples/helpers/HGetPools.sol
+++ b/packages/contracts/src/examples/helpers/HGetPools.sol
@@ -86,25 +86,16 @@ contract HGetPools {
         PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            address poolAddress;
-            string memory name;
-            string memory symbol;
-            uint256 poolId;
-            address owner;
-            (
-                poolAddress,
-                name,
-                symbol,
-                poolId,
-                owner,
-                groups[i]
-            ) = dragoRegistryInstance.fromId(i);
+            ( , , , , , groups[i]) = dragoRegistryInstance.fromId(i);
             if (groups[i] != _group) continue;
-            poolBaseData[i].poolAddress = poolAddress;
-            poolBaseData[i].name = name;
-            poolBaseData[i].symbol = symbol;
-            poolBaseData[i].poolId = poolId;
-            poolBaseData[i].owner = owner;
+            (
+                poolBaseData[i].poolAddress,
+                poolBaseData[i].name,
+                poolBaseData[i].symbol,
+                poolBaseData[i].poolId,
+                poolBaseData[i].owner,
+                
+            ) = dragoRegistryInstance.fromId(i);
         }
         return (poolBaseData);
     }
@@ -126,26 +117,18 @@ contract HGetPools {
         uint256 length = dragoRegistryInstance.dragoCount();
         PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
+        address[] memory owners = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            address poolAddress;
-            string memory name;
-            string memory symbol;
-            uint256 poolId;
-            address owner;
+            ( , , , , owners[i], groups[i]) = dragoRegistryInstance.fromId(i);
+            if (groups[i] != _group || owners[i] != address(msg.sender)) continue;
             (
-                poolAddress,
-                name,
-                symbol,
-                poolId,
-                owner,
-                groups[i]
+                poolBaseData[i].poolAddress,
+                poolBaseData[i].name,
+                poolBaseData[i].symbol,
+                poolBaseData[i].poolId,
+                poolBaseData[i].owner,
+
             ) = dragoRegistryInstance.fromId(i);
-            if (groups[i] != _group || poolBaseData[i].owner != address(msg.sender)) continue;
-            poolBaseData[i].poolAddress = poolAddress;
-            poolBaseData[i].name = name;
-            poolBaseData[i].symbol = symbol;
-            poolBaseData[i].poolId = poolId;
-            poolBaseData[i].owner = owner;
         }
         return (poolBaseData);
     }

--- a/packages/contracts/src/examples/helpers/HGetPools.sol
+++ b/packages/contracts/src/examples/helpers/HGetPools.sol
@@ -57,21 +57,12 @@ interface DragoRegistryFace {
 // solhint-disable-next-line
 contract HGetPools {
     
-    struct DragoData {
+    struct PoolBaseData {
+        address poolAddress;
         string name;
         string symbol;
-        uint256 sellPrice;
-        uint256 buyPrice;
+        uint256 dragoId;
         address owner;
-        address feeCollector;
-        address dragoDao;
-        uint256 ratio;
-        uint256 transactionFee;
-        uint256 totalSupply;
-        uint256 ethBalance;
-        uint32 minPeriod;
-        uint256 id;
-        address drago;
     }
 
     /*
@@ -80,52 +71,62 @@ contract HGetPools {
     /// @dev Returns structs of infos on a list of dragos for a group.
     /// @param _dragoRegistry Address of the pools registry.
     /// @param _group Number of the target drago group.
-    /// @return Arrays of structs of data and related address of a drago.
+    /// @return Arrays of structs of data and related address of a pool.
     function queryAllPoolsByGroup(
         address _dragoRegistry,
         address _group)
         external
         view
         returns (
-            address[] memory dragos,
-            string[]  memory names,
-            string[]  memory symbols,
-            uint256[]  memory dragoIds,
-            address[] memory owners
+            PoolBaseData[] memory
         )
     {
         DragoRegistryFace dragoRegistryInstance = DragoRegistryFace(_dragoRegistry);
         uint256 length = dragoRegistryInstance.dragoCount();
+        PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            (dragos[i], names[i], symbols[i], dragoIds[i], owners[i], groups[i]) = dragoRegistryInstance.fromId(i);
+            (
+                poolBaseData[i].poolAddress,
+                poolBaseData[i].name,
+                poolBaseData[i].symbol,
+                poolBaseData[i].dragoId,
+                poolBaseData[i].owner,
+                groups[i]
+            ) = dragoRegistryInstance.fromId(i);
             if (groups[i] != _group) continue;
         }
+        return (poolBaseData);
     }
-    
+
     /// @dev Returns structs of infos on a list of dragos for a group.
     /// @param _dragoRegistry Address of the pools registry.
     /// @param _group Number of the target drago group.
-    /// @return Arrays of structs of data and related address of a drago.
+    /// @return Arrays of structs of data and related address of a pool.
     function queryAllPoolsByCaller(
         address _dragoRegistry,
         address _group)
         external
         view
         returns (
-            address[] memory dragos,
-            string[]  memory names,
-            string[]  memory symbols,
-            uint256[]  memory dragoIds
+            PoolBaseData[] memory
         )
     {
         DragoRegistryFace dragoRegistryInstance = DragoRegistryFace(_dragoRegistry);
         uint256 length = dragoRegistryInstance.dragoCount();
-        address[] memory owners = new address[](length);
+        PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
-            (dragos[i], names[i], symbols[i], dragoIds[i], owners[i], groups[i]) = dragoRegistryInstance.fromId(i);
-            if (owners[i] != address(msg.sender) || groups[i] != _group) continue;
+            (
+                poolBaseData[i].poolAddress,
+                poolBaseData[i].name,
+                poolBaseData[i].symbol,
+                poolBaseData[i].dragoId,
+                poolBaseData[i].owner,
+                groups[i]
+            ) = dragoRegistryInstance.fromId(i);
+            if (groups[i] != _group || poolBaseData[i].owner != address(msg.sender)) continue;
         }
+        return (poolBaseData);
     }
 }

--- a/packages/contracts/src/examples/helpers/HGetPools.sol
+++ b/packages/contracts/src/examples/helpers/HGetPools.sol
@@ -61,7 +61,7 @@ contract HGetPools {
         address poolAddress;
         string name;
         string symbol;
-        uint256 dragoId;
+        uint256 poolId;
         address owner;
     }
 
@@ -86,15 +86,25 @@ contract HGetPools {
         PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
+            address poolAddress;
+            string memory name;
+            string memory symbol;
+            uint256 poolId;
+            address owner;
             (
-                poolBaseData[i].poolAddress,
-                poolBaseData[i].name,
-                poolBaseData[i].symbol,
-                poolBaseData[i].dragoId,
-                poolBaseData[i].owner,
+                poolAddress,
+                name,
+                symbol,
+                poolId,
+                owner,
                 groups[i]
             ) = dragoRegistryInstance.fromId(i);
             if (groups[i] != _group) continue;
+            poolBaseData[i].poolAddress = poolAddress;
+            poolBaseData[i].name = name;
+            poolBaseData[i].symbol = symbol;
+            poolBaseData[i].poolId = poolId;
+            poolBaseData[i].owner = owner;
         }
         return (poolBaseData);
     }
@@ -117,15 +127,25 @@ contract HGetPools {
         PoolBaseData[] memory poolBaseData = new PoolBaseData[](length);
         address[] memory groups = new address[](length);
         for (uint256 i = 0; i < length; i++) {
+            address poolAddress;
+            string memory name;
+            string memory symbol;
+            uint256 poolId;
+            address owner;
             (
-                poolBaseData[i].poolAddress,
-                poolBaseData[i].name,
-                poolBaseData[i].symbol,
-                poolBaseData[i].dragoId,
-                poolBaseData[i].owner,
+                poolAddress,
+                name,
+                symbol,
+                poolId,
+                owner,
                 groups[i]
             ) = dragoRegistryInstance.fromId(i);
             if (groups[i] != _group || poolBaseData[i].owner != address(msg.sender)) continue;
+            poolBaseData[i].poolAddress = poolAddress;
+            poolBaseData[i].name = name;
+            poolBaseData[i].symbol = symbol;
+            poolBaseData[i].poolId = poolId;
+            poolBaseData[i].owner = owner;
         }
         return (poolBaseData);
     }

--- a/packages/contracts/src/examples/helpers/HGetPools.sol
+++ b/packages/contracts/src/examples/helpers/HGetPools.sol
@@ -1,6 +1,6 @@
 /*
 
- Copyright 2018 RigoBlock, Rigo Investment Sagl.
+ Copyright 2018-2019 RigoBlock, Rigo Investment Sagl, 2020 Rigo Intl.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,38 +16,60 @@
 
 */
 
-pragma solidity 0.4.25;
+pragma solidity 0.5.0;
 pragma experimental ABIEncoderV2;
 
-/// @title Drago Registry Interface - Allows external intaction with Drago Registry.
-/// @author Gabriele Rigo - <gab@rigoblock.com>
-// solhint-disable-next-line
-
-import { DragoRegistryFace as Registry } from "../../protocol/DragoRegistry/DragoRegistryFace.sol";
+import { DragoRegistryFace } from "../../protocol/DragoRegistry/DragoRegistryFace.sol";
 
 /// @title Multiple Balances Helper - Allows to receive a list of pools for a specific group.
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 contract HGetPools {
 
-    function queryPools(
+    function queryAllPoolsByGroup(
         address _registry,
         address _group)
         external
         view
         returns (
-            address[] dragos,
-            string[] names,
-            string[] symbols,
-            uint256[] dragoIds,
-            address[] owners
+            address[] memory dragos,
+            string[]  memory names,
+            string[]  memory symbols,
+            uint256[]  memory dragoIds,
+            address[]  memory owners
         )
     {
-        Registry registry = Registry(_registry);
+        DragoRegistryFace registry = DragoRegistryFace(_registry);
         uint256 length = registry.dragoCount();
         for (uint256 i = 0; i < length; i++) {
             (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group) = registry.fromId(i);
             if (group != _group) continue;
+            dragos[i] = drago;
+            names[i] = name;
+            symbols[i] = symbol;
+            dragoIds[i] = dragoId;
+            owners[i] = owner;
+        }
+    }
+    
+    function queryAllPoolsByCaller(
+        address _registry,
+        address _group)
+        external
+        view
+        returns (
+            address[] memory dragos,
+            string[]  memory names,
+            string[]  memory symbols,
+            uint256[]  memory dragoIds,
+            address[]  memory owners
+        )
+    {
+        DragoRegistryFace registry = DragoRegistryFace(_registry);
+        uint256 length = registry.dragoCount();
+        for (uint256 i = 0; i < length; i++) {
+            (address drago, string memory name, string memory symbol, uint256 dragoId, address owner, address group) = registry.fromId(i);
+            if (owner != address(msg.sender) || group != _group) continue;
             dragos[i] = drago;
             names[i] = name;
             symbols[i] = symbol;


### PR DESCRIPTION
return only operator pools

resolves #737 

#### :notebook: Overview
- fixed HGetPools helper contract to return list of pools
- returns a tuple with set of data: address, name, symbol, id, owner
- returns a fixed size array with empty values for non-queried pools
