### PR TITLE
Fix/remove spdx from abstract contracts

### DIFF
--- a/packages/contracts/src/staking/Staking.sol
+++ b/packages/contracts/src/staking/Staking.sol
@@ -47,31 +47,4 @@ contract Staking is
         _initMixinScheduler();
         _initMixinParams();
     }
-    
-    /// @dev Computes the reward owed to a pool during finalization.
-    ///      Does nothing if the pool is already finalized.
-    /// @param poolId The pool's ID.
-    /// @return totalReward The total reward owed to a pool.
-    /// @return membersStake The total stake for all non-operator members in
-    ///         this pool.
-    function _getUnfinalizedPoolRewards(bytes32 poolId)
-        internal
-        view
-        override(MixinPopRewards, MixinStakingPool)
-        returns (
-            uint256 totalReward,
-            uint256 membersStake)
-    {
-        (totalReward, membersStake) = MixinPopRewards._getUnfinalizedPoolRewards(poolId);
-    }
-
-    /// @dev Asserts that a pool has been finalized last epoch.
-    /// @param poolId The id of the pool that should have been finalized.
-    function _assertPoolFinalizedLastEpoch(bytes32 poolId)
-        internal
-        view
-        override(MixinPopRewards, MixinStakingPool)
-    {
-        return MixinPopRewards._assertPoolFinalizedLastEpoch(poolId);
-    }
 }

--- a/packages/contracts/src/staking/immutable/MixinConstants.sol
+++ b/packages/contracts/src/staking/immutable/MixinConstants.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/immutable/MixinDeploymentConstants.sol
+++ b/packages/contracts/src/staking/immutable/MixinDeploymentConstants.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/immutable/MixinStorage.sol
+++ b/packages/contracts/src/staking/immutable/MixinStorage.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IGrgVault.sol
+++ b/packages/contracts/src/staking/interfaces/IGrgVault.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IStaking.sol
+++ b/packages/contracts/src/staking/interfaces/IStaking.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IStakingEvents.sol
+++ b/packages/contracts/src/staking/interfaces/IStakingEvents.sol
@@ -1,4 +1,21 @@
-// SPDX-License-Identifier: Apache 2.0
+/*
+
+  Original work Copyright 2019 ZeroEx Intl.
+  Modified work Copyright 2020 Rigo Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 
 pragma solidity >=0.5.9 <0.8.0;
 

--- a/packages/contracts/src/staking/interfaces/IStakingProxy.sol
+++ b/packages/contracts/src/staking/interfaces/IStakingProxy.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IStorage.sol
+++ b/packages/contracts/src/staking/interfaces/IStorage.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IStorageInit.sol
+++ b/packages/contracts/src/staking/interfaces/IStorageInit.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/interfaces/IStructs.sol
+++ b/packages/contracts/src/staking/interfaces/IStructs.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/libs/LibCobbDouglas.sol
+++ b/packages/contracts/src/staking/libs/LibCobbDouglas.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/libs/LibFixedMath.sol
+++ b/packages/contracts/src/staking/libs/LibFixedMath.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Copyright 2017 Bprotocol Foundation, 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/libs/LibFixedMathRichErrors.sol
+++ b/packages/contracts/src/staking/libs/LibFixedMathRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/libs/LibSafeDowncast.sol
+++ b/packages/contracts/src/staking/libs/LibSafeDowncast.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/libs/LibStakingRichErrors.sol
+++ b/packages/contracts/src/staking/libs/LibStakingRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/rewards/MixinPopManager.sol
+++ b/packages/contracts/src/staking/rewards/MixinPopManager.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/rewards/MixinPopRewards.sol
+++ b/packages/contracts/src/staking/rewards/MixinPopRewards.sol
@@ -144,33 +144,4 @@ abstract contract MixinPopRewards is
         );
         return (membersStake, weightedStake);
     }
-
-    /// @dev Computes the reward owed to a pool during finalization.
-    ///      Does nothing if the pool is already finalized.
-    /// @param poolId The pool's ID.
-    /// @return totalReward The total reward owed to a pool.
-    /// @return membersStake The total stake for all non-operator members in
-    ///         this pool.
-    function _getUnfinalizedPoolRewards(bytes32 poolId)
-        internal
-        view
-        virtual
-        override(MixinFinalizer, MixinStakingPool)
-        returns (
-            uint256 totalReward,
-            uint256 membersStake)
-    {
-        (totalReward, membersStake) = MixinFinalizer._getUnfinalizedPoolRewards(poolId);
-    }
-
-    /// @dev Asserts that a pool has been finalized last epoch.
-    /// @param poolId The id of the pool that should have been finalized.
-    function _assertPoolFinalizedLastEpoch(bytes32 poolId)
-        internal
-        view
-        virtual
-        override(MixinFinalizer, MixinStakingPool)
-    {
-        return MixinFinalizer._assertPoolFinalizedLastEpoch(poolId);
-    }
 }

--- a/packages/contracts/src/staking/rewards/MixinPopRewards.sol
+++ b/packages/contracts/src/staking/rewards/MixinPopRewards.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/stake/MixinStake.sol
+++ b/packages/contracts/src/staking/stake/MixinStake.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/stake/MixinStakeBalances.sol
+++ b/packages/contracts/src/staking/stake/MixinStakeBalances.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/stake/MixinStakeStorage.sol
+++ b/packages/contracts/src/staking/stake/MixinStakeStorage.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/staking_pools/MixinCumulativeRewards.sol
+++ b/packages/contracts/src/staking/staking_pools/MixinCumulativeRewards.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/staking_pools/MixinStakingPool.sol
+++ b/packages/contracts/src/staking/staking_pools/MixinStakingPool.sol
@@ -257,29 +257,4 @@ abstract contract MixinStakingPool is
             );
         }
     }
-
-    /// @dev Computes the reward owed to a pool during finalization.
-    ///      Does nothing if the pool is already finalized.
-    /// @param poolId The pool's ID.
-    /// @return totalReward The total reward owed to a pool.
-    /// @return membersStake The total stake for all non-operator members in
-    ///         this pool.
-    function _getUnfinalizedPoolRewards(bytes32 poolId)
-        internal
-        view
-        virtual
-        override(MixinAbstract, MixinStakingPoolRewards)
-        returns (
-            uint256 totalReward,
-            uint256 membersStake)
-    {}
-
-    /// @dev Asserts that a pool has been finalized last epoch.
-    /// @param poolId The id of the pool that should have been finalized.
-    function _assertPoolFinalizedLastEpoch(bytes32 poolId)
-        internal
-        view
-        virtual
-        override(MixinAbstract, MixinStakingPoolRewards)
-    {}
 }

--- a/packages/contracts/src/staking/staking_pools/MixinStakingPool.sol
+++ b/packages/contracts/src/staking/staking_pools/MixinStakingPool.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/staking_pools/MixinStakingPoolRewards.sol
+++ b/packages/contracts/src/staking/staking_pools/MixinStakingPoolRewards.sol
@@ -346,32 +346,4 @@ abstract contract MixinStakingPoolRewards is
         rewardsByPoolId[poolId] = rewardsByPoolId[poolId].safeSub(amount);
         grgReservedForPoolRewards = grgReservedForPoolRewards.safeSub(amount);
     }
-
-
-    /// @dev Computes the reward owed to a pool during finalization.
-    ///      Does nothing if the pool is already finalized.
-    /// @param poolId The pool's ID.
-    /// @return totalReward The total reward owed to a pool.
-    /// @return membersStake The total stake for all non-operator members in
-    ///         this pool.
-    function _getUnfinalizedPoolRewards(bytes32 poolId)
-        internal
-        view
-        virtual
-        override
-        returns (
-            uint256 totalReward,
-            uint256 membersStake)
-    // solhint-disable-next-line
-    {}
-
-    /// @dev Asserts that a pool has been finalized last epoch.
-    /// @param poolId The id of the pool that should have been finalized.
-    function _assertPoolFinalizedLastEpoch(bytes32 poolId)
-        internal
-        view
-        virtual
-        override
-    // solhint-disable-next-line
-    {}
 }

--- a/packages/contracts/src/staking/staking_pools/MixinStakingPoolRewards.sol
+++ b/packages/contracts/src/staking/staking_pools/MixinStakingPoolRewards.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/sys/MixinAbstract.sol
+++ b/packages/contracts/src/staking/sys/MixinAbstract.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/sys/MixinFinalizer.sol
+++ b/packages/contracts/src/staking/sys/MixinFinalizer.sol
@@ -254,19 +254,4 @@ abstract contract MixinFinalizer is
             rewards = rewardsRemaining;
         }
     }
-
-    /// @dev Determines whether an address is an account or a contract
-    /// @param target Address to be inspected
-    /// @return Boolean the address is a contract
-    function _isContract(address target)
-        internal view
-        returns (bool)
-    {
-        uint size;
-        // solhint-disable-next-line
-        assembly {
-            size := extcodesize(target)
-        }
-        return size > 0;
-    }
 }

--- a/packages/contracts/src/staking/sys/MixinFinalizer.sol
+++ b/packages/contracts/src/staking/sys/MixinFinalizer.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/sys/MixinParams.sol
+++ b/packages/contracts/src/staking/sys/MixinParams.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/staking/sys/MixinScheduler.sol
+++ b/packages/contracts/src/staking/sys/MixinScheduler.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/Authorizable.sol
+++ b/packages/contracts/src/utils/0xUtils/Authorizable.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/IAssetData.sol
+++ b/packages/contracts/src/utils/0xUtils/IAssetData.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/IAssetProxy.sol
+++ b/packages/contracts/src/utils/0xUtils/IAssetProxy.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/IERC20Token.sol
+++ b/packages/contracts/src/utils/0xUtils/IERC20Token.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Original work Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/IEtherToken.sol
+++ b/packages/contracts/src/utils/0xUtils/IEtherToken.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/LibAuthorizableRichErrors.sol
+++ b/packages/contracts/src/utils/0xUtils/LibAuthorizableRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
   Copyright 2019 ZeroEx Intl.
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/contracts/src/utils/0xUtils/LibFractions.sol
+++ b/packages/contracts/src/utils/0xUtils/LibFractions.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 pragma solidity >=0.5.4 <0.8.0;
 
 import "./LibSafeMath.sol";

--- a/packages/contracts/src/utils/0xUtils/LibMath.sol
+++ b/packages/contracts/src/utils/0xUtils/LibMath.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/LibMathRichErrors.sol
+++ b/packages/contracts/src/utils/0xUtils/LibMathRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 pragma solidity >=0.5.9 <0.8.0;
 
 

--- a/packages/contracts/src/utils/0xUtils/LibOwnableRichErrors.sol
+++ b/packages/contracts/src/utils/0xUtils/LibOwnableRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 pragma solidity >=0.5.9 <0.8.0;
 
 

--- a/packages/contracts/src/utils/0xUtils/LibRichErrors.sol
+++ b/packages/contracts/src/utils/0xUtils/LibRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
 
   Copyright 2019 ZeroEx Intl.

--- a/packages/contracts/src/utils/0xUtils/LibSafeMath.sol
+++ b/packages/contracts/src/utils/0xUtils/LibSafeMath.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 pragma solidity >=0.5.9 <0.8.0;
 
 import "./LibRichErrors.sol";

--- a/packages/contracts/src/utils/0xUtils/LibSafeMathRichErrors.sol
+++ b/packages/contracts/src/utils/0xUtils/LibSafeMathRichErrors.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 pragma solidity >=0.5.4 <0.8.0;
 
 

--- a/packages/contracts/src/utils/0xUtils/Ownable.sol
+++ b/packages/contracts/src/utils/0xUtils/Ownable.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
   Copyright 2019 ZeroEx Intl.
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/contracts/src/utils/0xUtils/interfaces/IAuthorizable.sol
+++ b/packages/contracts/src/utils/0xUtils/interfaces/IAuthorizable.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
   Copyright 2019 ZeroEx Intl.
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +13,9 @@
 
 pragma solidity >=0.5.9 <0.8.0;
 
-import "./IOwnable.sol";
 
+abstract contract IAuthorizable {
 
-abstract contract IAuthorizable is
-    IOwnable
-{
     // Event logged when a new address is authorized.
     event AuthorizedAddressAdded(
         address indexed target,

--- a/packages/contracts/src/utils/0xUtils/interfaces/IOwnable.sol
+++ b/packages/contracts/src/utils/0xUtils/interfaces/IOwnable.sol
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache 2.0
-
 /*
   Copyright 2019 ZeroEx Intl.
   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION

#### :notebook: Overview
removes SPDX identifiers from abstract contracts

#### :warning: Dependencies (optional)
Depends on #774 
