### PR TITLE
Fix/use try catch in end epoch

### DIFF
--- a/packages/contracts/src/staking/Staking.sol
+++ b/packages/contracts/src/staking/Staking.sol
@@ -19,6 +19,7 @@
 
 */
 
+// solhint-disable-next-line
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 

--- a/packages/contracts/src/staking/sys/MixinFinalizer.sol
+++ b/packages/contracts/src/staking/sys/MixinFinalizer.sol
@@ -57,8 +57,16 @@ abstract contract MixinFinalizer is
         }
 
         // mint epoch inflation, jump first epoch as all regitered pool accounts will become active from following epoch
+        //  mint happens before time has passed check, therefore tokens will be allocated even before expiry if method is called
+        //  but will not be minted again until epoch time has passed. This could happen when epoch length is changed only.
         if (currentEpoch_ > uint256(1)) {
-            InflationFace(getGrgContract().minter()).mintInflation();
+            try InflationFace(getGrgContract().minter()).mintInflation() returns (uint256 mintedInflation) {
+                return (mintedInflation);
+            } catch Error(string memory) {
+                return (0);
+            } catch (bytes memory) {
+                return (0);
+            }
         }
 
         // TODO: test


### PR DESCRIPTION
resolves #CHANGEME

#### :notebook: Overview
- fixes as edge case when endEpoch is called before enough time has passed, which reverts but mints the tokens to the staking proxy. This case does under default conditions, but could when an epoch length gets changed. This is a syntax logic fix, as the time has past check is performed after the inflation mint, therefore we must exclude reverts in the inflation contract (under current code the scenario will not happen, but theoretically could.

#### :warning: Dependencies (optional)
Depends on #CHANGEME
