### PR TITLE
interfaces linting

### DIFF
--- a/packages/contracts/src/rigoToken/Inflation/Inflation.sol
+++ b/packages/contracts/src/rigoToken/Inflation/Inflation.sol
@@ -35,14 +35,14 @@ contract Inflation is
     SafeMath,
     InflationFace
 {
-    address public immutable RIGO_TOKEN_ADDRESS;
-    address public immutable STAKING_PROXY_ADDRESS;
+    address public immutable override RIGO_TOKEN_ADDRESS;
+    address public immutable override STAKING_PROXY_ADDRESS;
 
+    uint256 public override slot;
+    uint256 public override epochLength;
+    
     uint32 internal immutable PPM_DENOMINATOR = 10**6; // 100% in parts-per-million
     uint256 internal immutable ANNUAL_INFLATION_RATE = 2 * 10**4; // 2% annual inflation
-
-    uint256 public slot;
-    uint256 public epochLength;
 
     uint256 private epochEndTime;
 

--- a/packages/contracts/src/rigoToken/Inflation/InflationFace.sol
+++ b/packages/contracts/src/rigoToken/Inflation/InflationFace.sol
@@ -22,26 +22,62 @@ pragma solidity >=0.4.22 <0.8.0;
 /// @author Gabriele Rigo - <gab@rigoblock.com>
 // solhint-disable-next-line
 interface InflationFace {
+    
+    /*
+     * PUBLIC VARIABLES
+     */
+    // solhint-disable-next-line
+    function RIGO_TOKEN_ADDRESS()
+        external
+        view
+        returns (address);
+
+    //solhint-disable-next-line
+    function STAKING_PROXY_ADDRESS()
+        external
+        view
+        returns (address);
+
+    function slot()
+        external
+        view
+        returns (uint256);
+
+    function epochLength()
+        external
+        view
+        returns (uint256);
 
     /*
      * CORE FUNCTIONS
      */
     /// @dev Allows staking proxy to mint rewards.
     /// @return mintedInflation Number of allocated tokens.
-    function mintInflation() external returns (uint256 mintedInflation);
+    function mintInflation()
+        external
+        returns (uint256 mintedInflation);
 
     /*
      * CONSTANT PUBLIC FUNCTIONS
      */
     /// @dev Returns whether an epoch has ended.
     /// @return Bool the epoch has ended.
-    function epochEnded() external view returns (bool);
+    function epochEnded()
+        external
+        view
+        returns (bool);
     
     /// @dev Returns how long until next claim.
     /// @return Number in seconds.
-    function timeUntilNextClaim() external view returns (uint256);
+    function timeUntilNextClaim()
+        external
+        view
+        returns (uint256);
     
     /// @dev Returns the epoch inflation.
     /// @return Value of units of GRG minted in an epoch.
-    function getEpochInflation() external view returns (uint256);
+    function getEpochInflation()
+        external
+        view
+        returns (uint256);
 }

--- a/packages/contracts/src/rigoToken/ProofOfPerformance/ProofOfPerformance.sol
+++ b/packages/contracts/src/rigoToken/ProofOfPerformance/ProofOfPerformance.sol
@@ -25,7 +25,6 @@ import { AuthorityFace } from "../../protocol/authorities/Authority/AuthorityFac
 import { IPool } from "../../utils/Pool/IPool.sol";
 import { SafeMath } from "../../utils/SafeMath/SafeMath.sol";
 import { ProofOfPerformanceFace } from "./ProofOfPerformanceFace.sol";
-import { RigoTokenFace } from "../RigoToken/RigoTokenFace.sol";
 import { IDragoRegistry } from "../../protocol/DragoRegistry/IDragoRegistry.sol";
 import { IStaking } from "../../staking/interfaces/IStaking.sol";
 
@@ -37,16 +36,15 @@ contract ProofOfPerformance is
     SafeMath,
     ProofOfPerformanceFace
 {
-    address public immutable RIGO_TOKEN_ADDRESS;
-    address public immutable STAKING_PROXY_ADDRESS;
-
-    address public dragoRegistryAddress;
-    address public rigoblockDaoAddress;
-    address public authorityAddress;
+    address public override dragoRegistryAddress;
+    address public override rigoblockDaoAddress;
+    address public override authorityAddress;
+    
+    address private immutable STAKING_PROXY_ADDRESS;
 
     mapping (address => Group) public groupByAddress;
     mapping (uint256 => uint256) private _highWaterMark;
-
+    
     struct Group {
         uint256 epochReward;
         uint256 rewardRatio;
@@ -68,13 +66,11 @@ contract ProofOfPerformance is
     }
 
     constructor(
-        address _rigoTokenAddress,
         address _stakingProxyAddress,
         address _rigoblockDao,
         address _dragoRegistry,
         address _authorityAddress
     ) {
-        RIGO_TOKEN_ADDRESS = _rigoTokenAddress;
         STAKING_PROXY_ADDRESS = _stakingProxyAddress;
         rigoblockDaoAddress = _rigoblockDao;
         dragoRegistryAddress = _dragoRegistry;
@@ -150,7 +146,8 @@ contract ProofOfPerformance is
     /// @notice onlyRigoblockDao can set ratio.
     function setRatio(
         address groupAddress,
-        uint256 newRatio)
+        uint256 newRatio
+    )
         external
         override
         onlyRigoblockDao
@@ -165,7 +162,10 @@ contract ProofOfPerformance is
     /// @dev Allows rigoblock dao to set the inflation factor for a group.
     /// @param groupAddress Address of the group/factory.
     /// @param inflationFactor Value of the reward factor.
-    function setInflationFactor(address groupAddress, uint256 inflationFactor)
+    function setInflationFactor(
+        address groupAddress,
+        uint256 inflationFactor
+    )
         external
         override
         onlyRigoblockDao
@@ -267,7 +267,10 @@ contract ProofOfPerformance is
         external
         view
         override
-        returns (uint256 popReward, uint256 performanceReward)
+        returns (
+            uint256 popReward,
+            uint256 performanceReward
+        )
     {
         return _proofOfPerformanceInternal(poolId);
     }
@@ -323,9 +326,7 @@ contract ProofOfPerformance is
         external
         view
         override
-        returns (
-            uint256 aum
-        )
+        returns (uint256 aum)
     {
         ( , , aum) = _getPoolPriceAndValueInternal(poolId);
     }
@@ -366,7 +367,10 @@ contract ProofOfPerformance is
     function _proofOfPerformanceInternal(uint256 poolId)
         internal
         view
-        returns (uint256 popReward, uint256 performanceReward)
+        returns (
+            uint256 popReward,
+            uint256 performanceReward
+        )
     {
         (uint256 newPrice, uint256 tokenSupply, uint256 poolValue) = _getPoolPriceAndValueInternal(poolId);
         (address poolAddress, ) = _addressFromIdInternal(poolId);
@@ -553,7 +557,8 @@ contract ProofOfPerformance is
     /// @param target Address to be inspected
     /// @return Boolean the address is a contract
     function _isContract(address target)
-        internal view
+        internal
+        view
         returns (bool)
     {
         uint size;

--- a/packages/contracts/src/rigoToken/ProofOfPerformance/ProofOfPerformanceFace.sol
+++ b/packages/contracts/src/rigoToken/ProofOfPerformance/ProofOfPerformanceFace.sol
@@ -24,34 +24,64 @@ pragma solidity >=0.4.22 <0.8.0;
 interface ProofOfPerformanceFace {
     
     /*
+     * PUBLIC VARIABLES
+     */
+    function dragoRegistryAddress()
+        external
+        view
+        returns (address);
+
+    function rigoblockDaoAddress()
+        external
+        view
+        returns (address);
+
+    function authorityAddress()
+        external
+        view
+        returns (address);
+
+    /*
      * CORE FUNCTIONS
      */
     /// @dev Credits the pop reward to the Staking Proxy contract.
     /// @param poolId Number of the pool Id in registry.
-    function creditPopRewardToStakingProxy(uint256 poolId) external;
+    function creditPopRewardToStakingProxy(uint256 poolId)
+        external;
 
     /// @dev Allows RigoBlock Dao to update the pools registry.
     /// @param newDragoRegistryAddress Address of new registry.
-    function setRegistry(address newDragoRegistryAddress) external;
+    function setRegistry(address newDragoRegistryAddress)
+        external;
 
     /// @dev Allows RigoBlock Dao to update its address.
     /// @param newRigoblockDaoAddress Address of new dao.
-    function setRigoblockDao(address newRigoblockDaoAddress) external;
+    function setRigoblockDao(address newRigoblockDaoAddress)
+        external;
     
     /// @dev Allows rigoblock dao to update the authority.
     /// @param newAuthorityAddress Address of the authority.
-    function setAuthority(address newAuthorityAddress) external;
+    function setAuthority(address newAuthorityAddress)
+        external;
 
     /// @dev Allows RigoBlock Dao to set the ratio between assets and performance reward for a group.
     /// @param groupAddress Address of the pool's group.
     /// @param newRatio Value of the new ratio.
     /// @notice onlyRigoblockDao can set ratio.
-    function setRatio(address groupAddress, uint256 newRatio) external;
+    function setRatio(
+        address groupAddress,
+        uint256 newRatio
+    )
+        external;
     
     /// @dev Allows rigoblock dao to set the inflation factor for a group.
     /// @param groupAddress Address of the group/factory.
     /// @param inflationFactor Value of the reward factor.
-    function setInflationFactor(address groupAddress, uint256 inflationFactor) external;
+    function setInflationFactor(
+        address groupAddress,
+        uint256 inflationFactor
+    )
+        external;
 
     /*
      * CONSTANT PUBLIC FUNCTIONS
@@ -85,7 +115,10 @@ interface ProofOfPerformanceFace {
     /// @dev Returns the highwatermark of a pool.
     /// @param poolId Id of the pool.
     /// @return Value of the all-time-high pool nav.
-    function getHwm(uint256 poolId) external view returns (uint256);
+    function getHwm(uint256 poolId)
+        external
+        view
+        returns (uint256);
 
     /// @dev Returns the split ratio of asset and performance reward.
     /// @param poolId Id of the pool.
@@ -112,7 +145,9 @@ interface ProofOfPerformanceFace {
     function proofOfPerformance(uint256 poolId)
         external
         view
-        returns (uint256 popReward, uint256 performanceReward);
+        returns (
+            uint256 popReward,
+            uint256 performanceReward);
 
     /// @dev Checks whether a pool is registered and active.
     /// @param poolId Id of the pool.
@@ -152,7 +187,5 @@ interface ProofOfPerformanceFace {
     function calcPoolValue(uint256 poolId)
         external
         view
-        returns (
-            uint256 aum
-        );
+        returns (uint256 aum);
 }


### PR DESCRIPTION

#### :notebook: Overview

- expose public variables in pop, inflation interfaces
- use override in implementations
- removed unused import
- remove unused input in constructor
- methods interfaces linting

