### PR TITLE
generate api contracts list from generated-artifacts folder

### DIFF
--- a/packages/contracts/fetchContracts.js
+++ b/packages/contracts/fetchContracts.js
@@ -5,7 +5,7 @@ require('regenerator-runtime')
 module.exports.default = async networkId => {
   const artifacts = CONTRACT_NAMES.map(contractName => `${contractName}.json`)
   const abisPromises = artifacts.map(async artifact => {
-    const json = await import('./artifacts/' + artifact)
+    const json = await import('./generated-artifacts/' + artifact)
     if (!json['networks'][networkId]) {
       throw new Error(
         `Make sure contracts are deployed for network Id ${networkId}`


### PR DESCRIPTION

#### :notebook: Overview
builds api contracts list from folder /contracts/generated-artifacts instead of /contracts/artifacts

### :warning: Dependencies
Fails as @rgbk/api does not recognize the ABIs inside the generated-artifacts .json files


